### PR TITLE
feat: page specific help button in project scope

### DIFF
--- a/shared/src/components/Feedback/FeedbackContext.tsx
+++ b/shared/src/components/Feedback/FeedbackContext.tsx
@@ -12,6 +12,7 @@ export type FeedbackContextType = {
   openSupport: (
     page?: 'Home' | 'Messages' | 'Changelog' | 'Help' | 'NewMessage' | 'ShowArticle',
     id?: string,
+    keepOpen?: boolean
   ) => void
   messengerLoaded: boolean // whether the messenger widget is loaded
   unreadCount: number // number of unread messages
@@ -333,7 +334,7 @@ export const FeedbackProvider: React.FC<FeedbackProviderProps> = ({ children }) 
     }
   }, [scriptLoaded, messengerLoaded])
 
-  const openSupport: FeedbackContextType['openSupport'] = (page = 'Home', id) => {
+  const openSupport: FeedbackContextType['openSupport'] = (page = 'Home', id, keepOpen = false) => {
     const win = window as any
     if (typeof win.Featurebase !== 'function') {
       window.alert('Featurebase SDK is not loaded yet. Please try again later.')
@@ -341,8 +342,8 @@ export const FeedbackProvider: React.FC<FeedbackProviderProps> = ({ children }) 
       return
     }
 
-    if (messengerVisibility) {
-      //  if the messenger is already visible, close it
+    if (messengerVisibility && !keepOpen) {
+      //  if the messenger is already visible, close it (unless explicitly requested)
       win.Featurebase('hide')
       setMessengerVisibility(false)
       return

--- a/src/containers/header/AppNavLinks.jsx
+++ b/src/containers/header/AppNavLinks.jsx
@@ -70,6 +70,7 @@ const AppNavLinks = ({ links = [] }) => {
               endContent,
               uriSync,
               module,
+              as,
               ...props
             } = {},
             idx,
@@ -87,7 +88,10 @@ const AppNavLinks = ({ links = [] }) => {
               // if item is a node a spacer, return spacer
               if (node === 'spacer') {
                 return <Spacer key={idx} />
-              } else return <li key={idx}>{node}</li>
+              } else {
+                const Wrapper = as || 'li'
+                return <Wrapper key={idx}>{node}</Wrapper>
+              }
             }
 
             return (

--- a/src/containers/header/AppNavLinks.styled.js
+++ b/src/containers/header/AppNavLinks.styled.js
@@ -64,3 +64,17 @@ export const NavItem = styled.li`
     }
   }
 `
+
+export const NavItemRightSticky = styled.li`
+  display: flex;
+  flex-direction: row;
+  position: sticky;
+  right: 0;
+
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--panel-background), transparent 5%) 2em);
+  padding-left: 2em;
+
+  /* make it so the background extends on top, in order to cover an active (taller) tab */
+  margin-top: -1em;
+  padding-top: 1em;
+`

--- a/src/containers/header/AppNavLinks.styled.js
+++ b/src/containers/header/AppNavLinks.styled.js
@@ -75,6 +75,14 @@ export const NavItemRightSticky = styled.li`
   padding-left: 2em;
 
   /* make it so the background extends on top, in order to cover an active (taller) tab */
-  margin-top: -1em;
-  padding-top: 1em;
+  margin-top: -1px;
+  padding-top: 3px;
+  padding-bottom: 2px;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    left: 0; height: 1px; bottom: 0; right: 0;
+    background: linear-gradient(90deg, transparent, var(--md-sys-color-outline-variant) 1.5em);
+  }
 `

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -24,10 +24,11 @@ import { Navigate } from 'react-router-dom'
 import ProjectPubSub from './ProjectPubSub'
 import NewListFromContext from '@pages/ProjectListsPage/components/NewListDialog/NewListFromContext'
 import { RemoteAddonProject } from '@shared/context'
-import { VersionUploadProvider, UploadVersionDialog } from '@shared/components'
+import { VersionUploadProvider, UploadVersionDialog, useFeedback } from '@shared/components'
 import { productSelected } from '@state/context'
 import useGetBundleAddonVersions from '@hooks/useGetBundleAddonVersions'
 import ProjectReviewsPage from '@pages/ProjectListsPage/ProjectReviewsPage'
+import { upperFirst } from 'lodash'
 
 const ProjectContextInfo = () => {
   /**
@@ -65,6 +66,15 @@ const ProjectPage = () => {
     { projectName: projectName || '' },
     { skip: !projectName },
   )
+  const { openSupport } = useFeedback()
+
+  // this list is populated from https://help.ayon.app/collections/0376560-production-tracking
+  const moduleArticleMapping: Record<string, string> = {
+    'overview': '7885519',
+    'tasks': '5526719',
+    'lists': '7382645',
+    'reviews': '8669165',
+  } as const
 
   const {
     data: addonsData = [],
@@ -169,6 +179,20 @@ const ProjectPage = () => {
       {
         node: (
           <Button
+            icon={(module in moduleArticleMapping) ? 'help' : 'live_help'}
+            onClick={() => {
+              if (module in moduleArticleMapping)
+                openSupport('ShowArticle', moduleArticleMapping[module])
+              else
+                openSupport('NewMessage', `Can you help me know more about the ${upperFirst(module)} page?`)
+            }}
+            variant='text'
+          />
+        )
+      },
+      {
+        node: (
+          <Button
             icon="more_horiz"
             onClick={() => {
               setShowContextDialog(true)
@@ -178,7 +202,7 @@ const ProjectPage = () => {
         ),
       },
     ],
-    [addonsData, projectName, remotePages, matchedAddons],
+    [addonsData, projectName, module, remotePages, matchedAddons],
   )
 
   //

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -182,9 +182,9 @@ const ProjectPage = () => {
             icon={(module in moduleArticleMapping) ? 'help' : 'live_help'}
             onClick={() => {
               if (module in moduleArticleMapping)
-                openSupport('ShowArticle', moduleArticleMapping[module])
+                openSupport('ShowArticle', moduleArticleMapping[module], true)
               else
-                openSupport('NewMessage', `Can you help me know more about the ${upperFirst(module)} page?`)
+                openSupport('NewMessage', `Can you help me know more about the ${upperFirst(module)} page?`, true)
             }}
             variant='text'
           />

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -17,6 +17,7 @@ import { useGetProjectQuery } from '@queries/project/enhancedProject'
 import { useGetProjectAddonsQuery } from '@shared/api'
 import { TabPanel, TabView } from 'primereact/tabview'
 import AppNavLinks from '@containers/header/AppNavLinks'
+import { NavItemRightSticky } from '@containers/header/AppNavLinks.styled'
 import { SlicerProvider } from '@context/SlicerContext'
 import { EntityListsProvider } from '@pages/ProjectListsPage/context'
 import useLoadRemoteProjectPages from '../../remote/useLoadRemotePages'
@@ -177,28 +178,27 @@ const ProjectPage = () => {
         })),
       { node: 'spacer' },
       {
+        as: NavItemRightSticky,
         node: (
-          <Button
-            icon={(module in moduleArticleMapping) ? 'help' : 'live_help'}
-            onClick={() => {
-              if (module in moduleArticleMapping)
-                openSupport('ShowArticle', moduleArticleMapping[module], true)
-              else
-                openSupport('NewMessage', `Can you help me know more about the ${upperFirst(module)} page?`, true)
-            }}
-            variant='text'
-          />
-        )
-      },
-      {
-        node: (
-          <Button
-            icon="more_horiz"
-            onClick={() => {
-              setShowContextDialog(true)
-            }}
-            variant="text"
-          />
+          <>
+            <Button
+              icon={(module in moduleArticleMapping) ? 'help' : 'live_help'}
+              onClick={() => {
+                if (module in moduleArticleMapping)
+                  openSupport('ShowArticle', moduleArticleMapping[module], true)
+                else
+                  openSupport('NewMessage', `Can you help me know more about the ${upperFirst(module)} page?`, true)
+              }}
+              variant='text'
+            />
+            <Button
+              icon="more_horiz"
+              onClick={() => {
+                setShowContextDialog(true)
+              }}
+              variant="text"
+            />
+          </>
         ),
       },
     ],


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Implements feature request from ynput/ayon-frontend#1294.

- Help button was added next to the Project Context button in the navbar
	- Buttons are always visible even if the tabs are overflowing
- Clicking from Overview, Task progress, Lists or Review pages will display their article
- On other pages with no linked article, the button will open the support chat with `Can you help me know more about the {module} page?` as the prompt

## Technical details
<!-- Please state any technical details such as limitations -->

- The `module` names have to have their respective article IDs mapped in [`src/pages/ProjectPage/ProjectPage.tsx`](https://github.com/vignedev/ayon-frontend/blob/e545803b6106139a9f605a09aaf4e611229a6f32/src/pages/ProjectPage/ProjectPage.tsx#L72-L77), specifically in `moduleArticleMapping`
	- If the article ID is not provided, the chat will be shown with the prompt as shown above, with the module name's first letter capitalized
	- The icon changes between `help` and `live_help` depending whether it would open an article or the chat respectively
- a4593c0 — For proper sticky buttons, links in `AppNavLinks` using `node` can be created as different elements than `li` — mostly meant to allow styled `li` elements
- ce6c7da — `openSupport(...)` would always act as a toggle, which may not be desired in certain areas, and such an additional overloading parameter `keepOpen` was added, which allows it to only change the page without affecting its visibility

## Additional context
<!-- Add any other context or screenshots here. -->
- How the buttons look like when the tabs in navbar are overflowing
    - Non-active tab under the overflown area
      <img width="667" height="160" alt="Screenshot from 2025-07-20 02-09-15_2" src="https://github.com/user-attachments/assets/c0300ca6-9464-4c88-a0ef-90d846f52ba2" />
    - Active tab under the overflown
      <img width="667" height="160" alt="Screenshot from 2025-07-20 02-09-15" src="https://github.com/user-attachments/assets/dd2babf0-5bd0-484e-8410-c7c40eb22f0c" />
- Video showing what the button does on a page with a known article:

https://github.com/user-attachments/assets/bfdde26c-8ccf-4e82-80b9-52af5e87d973

- Video showing button's behavior when a page does not have an article:

https://github.com/user-attachments/assets/28d71ac7-8ebf-42bf-9749-f9361646e6a8